### PR TITLE
Fix the resizing bug in HomeAnimation.vue

### DIFF
--- a/src/components/HomeAnimation.vue
+++ b/src/components/HomeAnimation.vue
@@ -552,7 +552,7 @@ export default {
         endTrigger: "#container5",
         // end: "bottom",
         onToggle: self => {
-          this.$refs.gif.src= resolvePath("/images/temp/homepage-panel3.gif")
+          this.$refs.gif.src = resolvePath("/images/temp/homepage-panel3.gif")
         }
       });
 
@@ -562,7 +562,7 @@ export default {
         endTrigger: "#contribute",
         // end: "bottom",
         onToggle: self => {
-          this.$refs.gif2.src= resolvePath("/images/temp/homepage-panel5.gif")
+          this.$refs.gif2.src = resolvePath("/images/temp/homepage-panel5.gif")
         }
       });
     }

--- a/src/components/HomeAnimation.vue
+++ b/src/components/HomeAnimation.vue
@@ -157,6 +157,7 @@
 </template>
 
 <script>
+import { resolvePath } from '@/utils/helpers.js'
 import Swoosh from './graphics/Swoosh.vue'
 import Sides from './graphics/Sides.vue'
 import Browser from './graphics/Browser.vue'
@@ -551,7 +552,7 @@ export default {
         endTrigger: "#container5",
         // end: "bottom",
         onToggle: self => {
-          this.$refs.gif.src=this.resolvePath("/images/temp/homepage-panel3.gif")
+          this.$refs.gif.src= resolvePath("/images/temp/homepage-panel3.gif")
         }
       });
 
@@ -561,7 +562,7 @@ export default {
         endTrigger: "#contribute",
         // end: "bottom",
         onToggle: self => {
-          this.$refs.gif2.src=this.resolvePath("/images/temp/homepage-panel5.gif")
+          this.$refs.gif2.src= resolvePath("/images/temp/homepage-panel5.gif")
         }
       });
     }

--- a/src/components/HomeAnimation.vue
+++ b/src/components/HomeAnimation.vue
@@ -238,6 +238,11 @@ export default {
 
   methods: {
     reset () {
+      // before performing browser reload, snap everything back to the initial scroll condition.
+      // so that the following execution of this.animateOnScroll() in mounted() hook can set up this animations properly. 
+      document.body.classList.add('is-resetting')
+      window.scrollTo({ top: 0, behavior: 'instant' })
+
       location.reload()
     },
     scrollTo(el) {
@@ -1131,6 +1136,13 @@ export default {
 
   @include phone {
     transform: scale(.5);
+  }
+}
+
+.is-resetting {
+  .c-face::after,
+  .c-face::before {
+    opacity: 0;
   }
 }
 

--- a/src/components/HomeAnimation.vue
+++ b/src/components/HomeAnimation.vue
@@ -157,7 +157,7 @@
 </template>
 
 <script>
-import { resolvePath } from '@/utils/helpers.js'
+import { resolvePath, debounceSimple } from '@/utils/helpers.js'
 import Swoosh from './graphics/Swoosh.vue'
 import Sides from './graphics/Sides.vue'
 import Browser from './graphics/Browser.vue'
@@ -176,6 +176,9 @@ export default {
 
   data() {
     return {
+      config: {
+        resizeHandler: debounceSimple(this.reset, 50)
+      },
       name: {
         1: 'Jess',
         3: 'Matt',
@@ -225,9 +228,12 @@ export default {
         }
       }, 500)
     }
-    setTimeout(() => {
-      window.addEventListener('resize', this.reset);
-    }, 1000)
+
+    window.addEventListener('resize', this.config.resizeHandler);
+  },
+
+  beforeDestroy () {
+    window.removeEventListener('resize', this.config.resizeHandler);
   },
 
   methods: {

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -28,7 +28,6 @@
 <script setup>
 import { isNavigationOpen, closeNavigation } from '../store.js';
 import { useStore } from '@nanostores/vue';
-import { resolvePath } from '@/utils/helpers.js'
 
 const $isNavigationOpen = useStore(isNavigationOpen);
 const menuList = [

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -7,3 +7,15 @@ export function resolvePath (relPath) {
   relPath = relPath.startsWith('/') ? relPath.slice(1) : relPath
   return `${import.meta.env.BASE_URL}${relPath}`
 }
+
+export function debounceSimple (callback, wait) {
+  let timeoutId = null
+
+  return (...args) => {
+    if (timeoutId) { clearTimeout(timeoutId) }
+
+    timeoutId = setTimeout(() => {
+      callback.apply(null, args)
+    }, wait)
+  }
+}


### PR DESCRIPTION
closes #67 

From my investigation, the root cause of the issue is as described below.

1. All the scroll-trigger animation stuff going on in the page is very sensitive to the viewport width&height. so the animation needs to be initialised again(happens in `mounted()` hook of the `HomeAnimation.vue`) every time the viewport size changes, and apparently the original author meant to achieve this by refreshing the page(executing `window.location.reload()`) in `resize` event handler, which works fine.

2. But the problem is that the `resize` event listener is currently set up within the callback of 1 sec timeout. 

3. This leads to a bug where the animation is sometimes initialised against the wrong viewport sizes, because the viewport width change can also happen during that `1 sec` gap between page refresh and the event listener attachment if the browser window is continuously increased/decreased (just like in your demo video @taoeffect)

**[ Solution ]**
So I made a fix where `resize` event listener is set up immediately after the component render but then also debounce it so that it makes sure to reset the animation against the correct viewport dimension.

Thanks,