### PR TITLE
#105 Update all image paths linked to /wp-content/*

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,8 @@ import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 import remarkBreaks from 'remark-breaks'; // improves support for newlines in markdown files
 import remarkGfm from 'remark-gfm'; // support rendering tables in markdown files
+import remarkMath from 'remark-math';
+import rehypeKatex from 'rehype-katex';
 // twitter & youtube auto-embed via remark
 import remarkEmbedder from '@remark-embedder/core';
 import oembedTransformer from '@remark-embedder/transformer-oembed';
@@ -37,13 +39,12 @@ export default defineConfig({
   base: IS_PROD_BUILD === 'true' ? "/" : '/groupincome.org',
   // integrations: [mdx(), sitemap(), vue()],
   integrations: [
+    mdx(),
     sitemap(),
     vue({ appEntrypoint: '/src/_app' })
   ],
   markdown: {
-    remarkPlugins: [remarkEmbedPlugin, remarkGfm, remarkBreaks, 'remark-math'],
-    rehypePlugins: [['rehype-katex', {
-      // Katex plugin options
-    }]]
+    remarkPlugins: [remarkEmbedPlugin, remarkGfm, remarkBreaks, remarkMath],
+    rehypePlugins: [[rehypeKatex, {}]]
   }
 });

--- a/src/pages/[...blog].astro
+++ b/src/pages/[...blog].astro
@@ -19,59 +19,65 @@ const { Content } = Astro.props
 <Content />
 
 <script>
-const footnoteEl = document.querySelector('section.footnotes')
+window.addEventListener('DOMContentLoaded', () => {
+  setTimeout(prepFootnotes, 100)
+})
 
-// NOTE:
-//  below is a logic to resolve a foonotes related bug(https://github.com/okTurtles/groupincome.org/issues/92)
-//  which is when links are clicked, the page is not scrolled to the correct positions.
-if (footnoteEl) {
-  const footnoteAnchorSel = 'a[data-footnote-ref]' // selector for an anchor tag linked to a footnote.
-  const footnoteBackSel = 'a[data-footnote-backref]' // selector for the 'back' anchor tag within a footnote.
-  const footnoteAnchors = Array.from(document.querySelectorAll(footnoteAnchorSel)) as HTMLAnchorElement[]
-  const footnoteBackEls = Array.from(document.querySelectorAll(footnoteBackSel)) as HTMLAnchorElement[]
-  const calcFloatingContents = (): number => {
-    // calculate the total height of the 'position: fixed' contents of the page.
-    // currently there is two UI components like that:  'fundraiser-banner', 'header-toolbar'
-    const floatingEls = ['.fundraiser', '.c-header-wrapper']
-    let totalHeight = 0
+function prepFootnotes () {
+  const footnoteEl = document.querySelector('section.footnotes')
 
-    floatingEls.forEach(sel => {
-      const el = document.querySelector(sel)
+  // NOTE:
+  //  below is a logic to resolve a foonotes related bug(https://github.com/okTurtles/groupincome.org/issues/92)
+  //  which is when links are clicked, the page is not scrolled to the correct positions.
+  if (footnoteEl) {
+    const footnoteAnchorSel = 'a[data-footnote-ref]' // selector for an anchor tag linked to a footnote.
+    const footnoteBackSel = 'a[data-footnote-backref]' // selector for the 'back' anchor tag within a footnote.
+    const footnoteAnchors = Array.from(document.querySelectorAll(footnoteAnchorSel)) as HTMLAnchorElement[]
+    const footnoteBackEls = Array.from(document.querySelectorAll(footnoteBackSel)) as HTMLAnchorElement[]
+    const calcFloatingContents = (): number => {
+      // calculate the total height of the 'position: fixed' contents of the page.
+      // currently there is two UI components like that:  'fundraiser-banner', 'header-toolbar'
+      const floatingEls = ['.fundraiser', '.c-header-wrapper']
+      let totalHeight = 0
 
-      if (el) {
-        const bbox = el.getBoundingClientRect()
-        totalHeight += bbox.height
-      }
-    })
+      floatingEls.forEach(sel => {
+        const el = document.querySelector(sel)
 
-    return totalHeight
-  }
-  const getAdjustedTargetScrollPosition = (targetId: string): number => {
-    // get adjusted scroll-Y value of the target element of an anchor tag.
-    // 'adjusted' here means subtracting the total heights of the floating contents of the page.
-    const targetEl = document.querySelector(`#${targetId}`)
-    if (targetEl) {
-      const bbox = targetEl.getBoundingClientRect()
-      return bbox.top + document.documentElement.scrollTop - calcFloatingContents()
+        if (el) {
+          const bbox = el.getBoundingClientRect()
+          totalHeight += bbox.height
+        }
+      })
+
+      return totalHeight
     }
-    return 0
-  }
-  const addClickHandlerWithAdjustment = (aTag: HTMLAnchorElement) => {
-    const href = aTag.href as string
-    const targetId = href ? href.split('#')[1] : ''
-
-    aTag.addEventListener('click', e => {
-      e.preventDefault()
-
-      const targetPositionY = getAdjustedTargetScrollPosition(targetId)
-      if (targetPositionY > 0) {
-        window.scrollTo({ top: targetPositionY, behavior: 'instant' })
+    const getAdjustedTargetScrollPosition = (targetId: string): number => {
+      // get adjusted scroll-Y value of the target element of an anchor tag.
+      // 'adjusted' here means subtracting the total heights of the floating contents of the page.
+      const targetEl = document.querySelector(`#${targetId}`)
+      if (targetEl) {
+        const bbox = targetEl.getBoundingClientRect()
+        return bbox.top + document.documentElement.scrollTop - calcFloatingContents()
       }
-    })
-  }
+      return 0
+    }
+    const addClickHandlerWithAdjustment = (aTag: HTMLAnchorElement) => {
+      const href = aTag.href as string
+      const targetId = href ? href.split('#')[1] : ''
 
-  footnoteAnchors.forEach(addClickHandlerWithAdjustment)
-  footnoteBackEls.forEach(addClickHandlerWithAdjustment)
+      aTag.addEventListener('click', e => {
+        e.preventDefault()
+
+        const targetPositionY = getAdjustedTargetScrollPosition(targetId)
+        if (targetPositionY > 0) {
+          window.scrollTo({ top: targetPositionY, behavior: 'instant' })
+        }
+      })
+    }
+
+    footnoteAnchors.forEach(addClickHandlerWithAdjustment)
+    footnoteBackEls.forEach(addClickHandlerWithAdjustment)
+  }
 }
 </script>
 

--- a/src/pages/[...blog].astro
+++ b/src/pages/[...blog].astro
@@ -20,6 +20,9 @@ const { Content } = Astro.props
 
 <script>
 window.addEventListener('DOMContentLoaded', () => {
+  // When this script is executed for any blog posts that are written as .mdx format, the logic inside prepFootnotes() does not work for some reason.
+  // But giving it a reasonable amount of delay ensures it consistently works for both .md and .mdx blog posts.
+  // (reference: https://github.com/okTurtles/groupincome.org/pull/107#discussion_r1547356061)
   setTimeout(prepFootnotes, 100)
 })
 

--- a/src/posts/a-reliable-safety-net-for-small-communities.mdx
+++ b/src/posts/a-reliable-safety-net-for-small-communities.mdx
@@ -13,6 +13,7 @@ permalink: /2020/07/a-reliable-safety-net-for-small-communities/
 categories:
     - Uncategorized
 ---
+import { resolvePath } from '@/utils/helpers.js'
 
 As misfortunes don't seem to come singly in 2020, the [COVID-19 pandemic](https://www.who.int/emergencies/diseases/novel-coronavirus-2019) is magnifying [social and economic inequality](https://graduateinstitute.ch/coronavirus-information-our-community-and-visitors/covid-19-magnifier-social-inequality) and accelerating an [economic collapse](https://www.cnbc.com/2020/06/29/nearly-half-the-us-population-is-without-a-job-showing-how-far-the-labor-recovery-has-to-go.html). As an answer, some people are [demanding disruptive change](https://www.chicagoreader.com/chicago/police-abolitionist-movement-alternatives-cops-chicago/Content?oid=23289710), because governments have been slow and [unsatisfactory in their response](https://www.ohchr.org/en/NewsEvents/Pages/DisplayNews.aspx?NewsID=25793&amp;LangID=E). There are several viewpoints on how to address these issues, but we came down to a dilemma: Should we rely on malfunctioning governments to be the answer? Or should we be resourceful and find tools, like Group Income, to build safety nets for ourselves and our communities?
 
@@ -28,7 +29,7 @@ Group Income solely relies on our sense of community, our ability to care for ea
 
 - **Why we consider communities so vital**
 
-<img src="https://groupincome.org/wp-content/uploads/2020/07/society-three-pillars.jpg" alt="" width="700" height="560" class="aligncenter size-full wp-image-1429" />
+<img src={resolvePath('wp-content/uploads/2020/07/society-three-pillars.jpg')} alt="" width="700" height="560" class="aligncenter size-full wp-image-1429" />
 
 Communities keep society balanced. Let's have a look at it from the standpoint of [Raghuram Rajan](https://www.chicagobooth.edu/faculty/directory/r/raghuram-g-rajan). The Chicago Booth professor explains that society is upheld by three fundamental pillars: governments (political pillar), markets (economic pillar), and communities (sociological pillar). 
 
@@ -42,7 +43,7 @@ According to Rajan, what happened across the industrial world was a continued vi
 
 **The consequence? The sociological pillar is now too fragile and there's an imbalance in society.**
 
-<img src="https://groupincome.org/wp-content/uploads/2020/07/society-broken-communities.jpg" alt="" width="700" height="560" class="aligncenter size-full wp-image-1430" />
+<img src={resolvePath('/wp-content/uploads/2020/07/society-broken-communities.jpg')} alt="" width="700" height="560" class="aligncenter size-full wp-image-1430" />
 
 **We no longer can deny [this imbalance](https://www.weforum.org/agenda/2018/11/unmanaged-globalisation-damaging-local-communities-heres-how). But how do we rectify it?** 
 

--- a/src/posts/aniko-fejes-and-sandrina-pereira-join-group-income.mdx
+++ b/src/posts/aniko-fejes-and-sandrina-pereira-join-group-income.mdx
@@ -13,10 +13,11 @@ permalink: /2018/08/aniko-fejes-and-sandrina-pereira-join-group-income/
 categories:
     - Uncategorized
 ---
+import { resolvePath } from '@/utils/helpers.js'
 
 Recently we bid farewell to [Victor Morrow](/articles/victor-morrow-joins-group-income/) who's moved on to exciting new [DARPA](https://www.darpa.mil) related work. Victor is still with us, now in a volunteer capacity. Thanks to his help, we've made great progress on Group Income. However, with his departure as full-time contractor, we needed to find someone to fill his shoes.
 
-<img src="https://groupincome.org/wp-content/uploads/2018/08/aniko-214x300.jpg" alt="" width="214" height="300" class="alignright size-medium wp-image-1133" />
+<img src={resolvePath('/wp-content/uploads/2018/08/aniko-214x300.jpg')} alt="" width="214" height="300" class="alignright size-medium wp-image-1133" />
 
 It was fortunate, therefore, that [Tamas Kalman](https://twitter.com/dH2K), another volunteer, introduced us to **Anikó Fejes**, a very talented developer and community organizer from Hungary.
 
@@ -26,7 +27,7 @@ Follow [@hubudibu](https://twitter.com/hubudibu) for the occasional tweet from h
 
 With Anikó on board, we were able to bring Group Income to the point where our focus had to shift away from internals and to the UI and UX of the app. In other words, we needed an expert frontend designer, and we found exactly what we were looking for in **Sandrina Pereira**.
 
-<img src="https://groupincome.org/wp-content/uploads/2018/08/sandrina-300x300.jpg" alt="" width="300" height="300" class="alignright size-medium wp-image-1132" />
+<img src={resolvePath('/wp-content/uploads/2018/08/sandrina-300x300.jpg')} alt="" width="300" height="300" class="alignright size-medium wp-image-1132" />
 
 Sandrina is a frontend developer with a great passion for interaction design. She loves to create unique experiences for <strike>users</strike> humans like you through the web.
 

--- a/src/posts/basic-security-our-real-goal.mdx
+++ b/src/posts/basic-security-our-real-goal.mdx
@@ -13,6 +13,7 @@ permalink: /2017/03/basic-security-our-real-goal/
 categories:
     - Uncategorized
 ---
+import { resolvePath } from '@/utils/helpers.js'
 
 Money is simply a tool that exists in circumstances when there is scarcity within an economy. It is a way of measuring the scarcity-demand for something. It is therefore a way of restricting access to that something. But when a lot of people choose to charge for scarce items using money, it gives money itself value -- value it otherwise would not have.
 
@@ -22,7 +23,7 @@ Confused, you'd ask, _"Kindness? What's that, and where do I get some?"_
 
 _"Well,"_ the shopkeep would say, _"You have to have a homeless person vouch for you. Their word is the currency that we take."_
 
-<img src="https://groupincome.org/wp-content/uploads/2017/03/kindness.jpg" alt="visual depiction of surrounding text" width="1420" height="569" class="alignnone size-full wp-image-943" />
+<img src={resolvePath('/wp-content/uploads/2017/03/kindness.jpg')} alt="visual depiction of surrounding text" width="1420" height="569" class="alignnone size-full wp-image-943" />
 
 You can imagine that would create an interesting situation. Suddenly, the value of simply being a homeless person would go up. These people would also have more power over society. The same thing happens with any currency, even dollars. If the creation of dollars is controlled by a small group (as it is), and those dollars are what shopkeeps around the country ask for, then that group suddenly becomes very powerful over society.
 

--- a/src/posts/bulgaria-hackathon-2019.mdx
+++ b/src/posts/bulgaria-hackathon-2019.mdx
@@ -14,12 +14,13 @@ permalink: /2021/06/bulgaria-hackathon-2019-roadmap-updates-hiring/
 categories:
     - Uncategorized
 ---
+import { resolvePath } from '@/utils/helpers.js'
 
 Some say it's not the destination that matters so much, but the journey and friends you meet along the way.
 
 I couldn't agree more. But also, destinations aren't to be underestimated either! Back in 2019, during the Before Times, our team — a mixture of independent contractors and volunteers — got together in the beautiful land of Bulgaria for **Hackathon #8**!
 
-<img src="https://groupincome.org/wp-content/uploads/2020/10/IMG_3732-768x1024.jpeg" alt="" width="768" height="1024" class="aligncenter size-large wp-image-1480" />
+<img src={resolvePath('/wp-content/uploads/2020/10/IMG_3732-768x1024.jpeg')} alt="" width="768" height="1024" class="aligncenter size-large wp-image-1480" />
 
 **In This Post**
 
@@ -36,13 +37,13 @@ Remember when people traveled? And did stuff? Together? In the same place? Wasn'
 Teammates from various parts of the world joined under a single roof, and this roof had two kinds of pools.
 
 <div class="gallery">
-<img src="https://groupincome.org/wp-content/uploads/2020/10/IMG_4028-300x225.jpeg"/>
-<img src="https://groupincome.org/wp-content/uploads/2020/10/IMG_4022-300x225.jpeg"/>
+	<img src={resolvePath('/wp-content/uploads/2020/10/IMG_4028-300x225.jpeg')} />
+	<img src={resolvePath('/wp-content/uploads/2020/10/IMG_4022-300x225.jpeg')} />
 </div>
 
 In attendance were familiar characters as well as new ones, including a brilliant young engineer and Group Income volunteer from South Korea by the name of [Sebin Song](https://sebinsong.github.io/).
 
-<img src="https://groupincome.org/wp-content/uploads/2020/10/IMG_20191018_172603.jpg"/>
+<img src={resolvePath('/wp-content/uploads/2020/10/IMG_20191018_172603.jpg')} />
 
 Sebin is one of the coolest people I've had to good fortune of meeting. He's an extremely intelligent, humble, and kind person whose talents in frontend development are exemplary.
 
@@ -58,36 +59,36 @@ I asked Sebin what he found exciting about Group Income, and what drew him to vo
 
 Most days we spent the morning, afternoon, and evenings working on Group Income.
 
-<img src="https://groupincome.org/wp-content/uploads/2020/10/IMG_3996.jpeg"/>
+<img src={resolvePath('/wp-content/uploads/2020/10/IMG_3996.jpeg')} />
 
 The team worked hard on implementing [Margarida's new dashboard designs](/2020/01/margarida-botelho-and-pierre-schweiger-join-group-income/):
 
-<img src="https://groupincome.org/wp-content/uploads/2020/01/gi-design-2-1024x682.jpg"/>
+<img src={resolvePath('/wp-content/uploads/2020/01/gi-design-2-1024x682.jpg')} />
 
 ### Food and exploration
 
 Andrea was our master vegan chef for the hackathon, and prepared a variety of delicious food for the team.
 
-<img src="https://groupincome.org/wp-content/uploads/2020/10/IMG_4025.jpeg"/>
+<img src={resolvePath('/wp-content/uploads/2020/10/IMG_4025.jpeg')} />
 
 Of course, we took time to explore Bulgaria too.
 
 The Black Sea is beautiful and was close to where we were staying.
 
-<img src="https://groupincome.org/wp-content/uploads/2020/10/IMG_3890.jpg"/>
+<img src={resolvePath('/wp-content/uploads/2020/10/IMG_3890.jpg')} />
 
-<img src="https://groupincome.org/wp-content/uploads/2020/10/IMG_20191021_174556.jpg"/>
+<img src={resolvePath('/wp-content/uploads/2020/10/IMG_20191021_174556.jpg')} />
 
-<img src="https://groupincome.org/wp-content/uploads/2020/10/IMG_20191021_175003.jpg"/>
+<img src={resolvePath('/wp-content/uploads/2020/10/IMG_20191021_175003.jpg')} />
 
 
 Pierre, always a fan of high-end restaurants, insisted that we visit one on the trip. This turned out to be a rather good idea, as the team loved the care with which one of Bulgaria's Master Chefs prepared each and every dish:
 
-<img src="https://groupincome.org/wp-content/uploads/2020/10/IMG_3899-1024x768.jpg"/>
+<img src={resolvePath('/wp-content/uploads/2020/10/IMG_3899-1024x768.jpg')} />
 
 I asked Pierre about his thoughts on Group Income. What was it that drew him to working on Group Income?
 
-<img src="https://groupincome.org/wp-content/uploads/2020/10/IMG_20191021_174559-300x300.jpg"/>
+<img src={resolvePath('/wp-content/uploads/2020/10/IMG_20191021_174559-300x300.jpg')} />
 
 > **"Our project is dedicated to people that care about each other and you can feel it from the inside: I've never been in a company that considers its people as human beings before being a workforce… and it just feels right."**
 >
@@ -97,9 +98,9 @@ I asked Pierre about his thoughts on Group Income. What was it that drew him to 
 
 ### Show & Tell
 <div class="gallery">
-<img width="300" height="225" src="https://groupincome.org/wp-content/uploads/2020/10/IMG_4035-300x225.jpeg"/>
-<img width="300" height="225" src="https://groupincome.org/wp-content/uploads/2020/10/IMG_4039-300x225.jpeg"/>
-<img width="300" height="225" src="https://groupincome.org/wp-content/uploads/2020/10/IMG_4046-300x225.jpeg"/>
+	<img width="300" height="225" src={resolvePath('/wp-content/uploads/2020/10/IMG_4035-300x225.jpeg')} />
+	<img width="300" height="225" src={resolvePath('/wp-content/uploads/2020/10/IMG_4039-300x225.jpeg')} />
+	<img width="300" height="225" src={resolvePath('/wp-content/uploads/2020/10/IMG_4046-300x225.jpeg')} />
 </div>
 
 Our hard work had paid off! We now have a mostly-functioning demo that anyone with a little bit of Git knowledge can [download and try out for themselves](https://github.com/okTurtles/group-income-simple)!
@@ -116,7 +117,7 @@ Many features came together during this hackathon:
 - Early implementation of the Pay Group page.
 - And my many more features and squashed bugs!
 
-<img src="https://groupincome.org/wp-content/uploads/2020/10/margarida-278x300.jpg"/>
+<img src={resolvePath('/wp-content/uploads/2020/10/margarida-278x300.jpg')} />
 
 > **"Working on this project has been one of the highlights of my professional life. I will be forever grateful for the opportunity to use my expertise, knowledge and time to contribute to this amazing project.**
 > 
@@ -155,7 +156,7 @@ Join our team!
 We're looking for:
 
 <ul>
-<li><h4 style="font-family: sans-serif"><a href="/pos-infosec/">JavaScript + InfoSec + Protocol Developer</a> ($1000 referral reward!)</a></h4></li>
+<li><h4 style="font-family: sans-serif"><a href="/pos-infosec/">JavaScript + InfoSec + Protocol Developer</a> ($1000 referral reward!)</h4></li>
 <li><h4 style="font-family: sans-serif"><a href="/pos-crypto-integration/">Cryptocurrency Integration with Node.js</a></h4></li>
 <li><h4 style="font-family: sans-serif"><a href="/pos-technical-writer/">Technical Writer</a></h4></li>
 <li><h4 style="font-family: sans-serif"><a href="/pos-fundraiser-marketer/">Fundraiser - OR - Marketer with Fundraising Experience</a></h4></li>
@@ -167,7 +168,7 @@ We're looking for:
 - **478 [issues closed](https://github.com/okTurtles/group-income-simple/issues?q=is%3Aissue+is%3Aclosed)**
 - **398 [pull requests reviewed](https://github.com/okTurtles/group-income-simple/pulls?q=is%3Apr+is%3Aclosed)**
 
-<img src="https://groupincome.org/wp-content/uploads/2020/10/IMG_3855.jpg"/>
+<img src={resolvePath('/wp-content/uploads/2020/10/IMG_3855.jpg')} />
 
 ## Participate In Group Income
 

--- a/src/posts/group-income-progress-update.mdx
+++ b/src/posts/group-income-progress-update.mdx
@@ -13,6 +13,7 @@ permalink: /2017/07/group-income-july-progress-update/
 categories:
     - Uncategorized
 ---
+import { resolvePath } from '@/utils/helpers.js'
 
 The Group Income prototype is nearing completion.
 
@@ -37,27 +38,27 @@ If your group wants to be among the first to try Group Income, keep a close eye 
 
 Among cows, horses, and sheep, surrounded by hills and grass, seven [totally OK turtles](https://okturtles.com) assembled.[^2]
 
-<img src="https://groupincome.org/wp-content/uploads/2017/07/nature.jpg" alt="" width="911" height="683" class="alignnone size-full wp-image-978" />
+<img src={resolvePath('/wp-content/uploads/2017/07/nature.jpg')} alt="" width="911" height="683" class="alignnone size-full wp-image-978" />
 
 We rented two nights at a countryside AirBnB. It featured a large, spacious interior — ideal for Getting Things Done.
 
 Shoes and social media were off. Electronic music was on.
 
 <div class="gallery">
-<img width="750" height="500" src="https://groupincome.org/wp-content/uploads/2017/07/discussion2.jpg" />
-<img width="750" height="500" src="https://groupincome.org/wp-content/uploads/2017/07/inside.jpg" />
+<img width="750" height="500" src={resolvePath('/wp-content/uploads/2017/07/discussion2.jpg')} />
+<img width="750" height="500" src={resolvePath('/wp-content/uploads/2017/07/inside.jpg')} />
 </div>
 
 I walked around with an iPad, looking important — err, I mean, I answered questions while going over the vision and remaining priorities.
 
 Andrea and Victor were in the kitchen, busy preparing a meal for everyone. Soon, the hackathon was well underway.
 
-<img src="https://groupincome.org/wp-content/uploads/2017/07/food2.jpg" alt="" width="1020" height="680" class="alignnone size-full wp-image-981" />
+<img src={resolvePath('/wp-content/uploads/2017/07/food2.jpg')} alt="" width="1020" height="680" class="alignnone size-full wp-image-981" />
 
 
 ### Who, What, Why
 
-<img src="https://groupincome.org/wp-content/uploads/2017/07/tamas-200x300.jpg" alt="" width="200" height="300" class="alignright size-medium wp-image-992" />
+<img src={resolvePath('/wp-content/uploads/2017/07/tamas-200x300.jpg')} alt="" width="200" height="300" class="alignright size-medium wp-image-992" />
 
 Joining us for the second time was Tamas Kalman. Tamas had previously helped out our group during the most recent [San Francisco Basic Income Create-A-Thon](https://www.youtube.com/watch?v=NADBkuEPMnA).
 
@@ -70,13 +71,13 @@ When asked what it is about Group Income that he finds most exciting, he said:
 > **"Group Income is the closest thing we could get to universal basic income, and we can make it happen right now, without waiting for state approval."**
 > — Tamas Kalman
 
-<img src="https://groupincome.org/wp-content/uploads/2017/07/outside-300x225.jpg" alt="" width="300" height="225" class="alignright size-medium wp-image-985" />
+<img src={resolvePath('/wp-content/uploads/2017/07/outside-300x225.jpg')} alt="" width="300" height="225" class="alignright size-medium wp-image-985" />
 
 Also present was Dana Woodman, who had already been helping us with the project but had yet to attend one of our hackathons. An entrepreneur as well, Dana's frontend skills are second-to-none, and in his spare time he teaches others how to use ReactJS, often at [the makerspace](https://www.chimeraarts.org) he co-founded. For Dana, the potential of Group Income lies beyond its use as a safety net, to its potential to serve as a dream enabler. For him, that dream is traveling more, and that means: _"Saving money for group trips with my close friends."_
 
 During the hackathon, Dana, along with David Ernst and Megan Cress, worked together to completely redesign and reinvent Group Income's user interface, paying special attention to the Group Dashboard — the most important screen in the app and the place users will likely spend the most time.
 
-<img src="https://groupincome.org/wp-content/uploads/2017/07/David-215x300.jpg" alt="" width="215" height="300" class="alignright size-medium wp-image-1030" />
+<img src={resolvePath('/wp-content/uploads/2017/07/David-215x300.jpg')} alt="" width="215" height="300" class="alignright size-medium wp-image-1030" />
 
 Like Tamas, this was David's second Group Income hackathon, having previously joined our group at the 2017 San Francisco Create-A-Thon. David, too, is an entrepreneur, and when he's not working on [liquid.vote](https://liquid.vote), he likes to help out various open source projects, including Group Income!
 
@@ -87,7 +88,7 @@ We asked David why he volunteers on Group Income, and he had this to say:
 
 The final member of the Dashboard team was Megan Cress, a strategy consultant and coach. This was Megan's first Group Income hackathon, and we have her to thank for all of the amazing photos of the event. Speaking of photos — it's totally my fault that we don't have a better picture of her besides the one I took on my phone (sorry!!!). That's her in the back, no doubt writing something brilliant:
 
-<img src="https://groupincome.org/wp-content/uploads/2017/07/IMG_0758.jpg" alt="" width="1020" height="728" class="alignnone size-full wp-image-1034" />
+<img src={resolvePath('/wp-content/uploads/2017/07/IMG_0758.jpg')} alt="" width="1020" height="728" class="alignnone size-full wp-image-1034" />
 
 Megan helped design the new Group Dashboard, and often acted as a catalyst for the team by asking great questions while making important contributions to the app itself, including critical adjustments to how our distribution algorithm works.
 
@@ -118,7 +119,7 @@ A former resident of Alaska, Andrea has first-hand experience when it comes to l
 
 The hackathon spanned two nights and three days. On the last day, we drove to Dana's markerspace where we buckled down and turtled our way to the finish line.
 
-<img src="https://groupincome.org/wp-content/uploads/2017/07/makerspace.jpg" alt="" width="1020" height="765" class="alignnone size-full wp-image-986" />
+<img src={resolvePath('/wp-content/uploads/2017/07/makerspace.jpg')} alt="" width="1020" height="765" class="alignnone size-full wp-image-986" />
 
 At the end of the long three day hackathon, the turtles deserved a break, and so we went out for dinner, drinks and several games of pool at a local bar. :)
 
@@ -140,7 +141,7 @@ It's been a long road...
 
 But we're almost there![^3]
 
-<img src="https://groupincome.org/wp-content/uploads/2017/07/dashboard.png" alt="" width="1082" height="1336" class="alignnone size-full wp-image-987" />
+<img src={resolvePath('/wp-content/uploads/2017/07/dashboard.png')} alt="" width="1082" height="1336" class="alignnone size-full wp-image-987" />
 
 [^3]: The final dashboard will look slightly different. Some elements, like the display of individual contribution amounts, will be removed, while others are being redesigned.
 

--- a/src/posts/hawaii-hackathon-2018.mdx
+++ b/src/posts/hawaii-hackathon-2018.mdx
@@ -17,8 +17,9 @@ tags:
     - progress
     - prototype
 ---
+import { resolvePath } from '@/utils/helpers.js'
 
-![IMG_3458_small](https://groupincome.org/wp-content/uploads/2019/04/IMG_3458_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/IMG_3458_small.jpg')} alt='IMG_3458_small' />
 
 Hawaii!
 
@@ -33,11 +34,11 @@ Home to many [great sea turtles](https://duckduckgo.com/?q=hawaii+sea+turtles&ia
 
 ## Hackathon #7 — Turtle Paradise
 
-![DSC03862_small](https://groupincome.org/wp-content/uploads/2019/04/DSC03862_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/DSC03862_small.jpg')} alt='DSC03862_small' />
 
 As guests trickled in to the AirBnB, [Sandrina Pereira](/articles/aniko-fejes-and-sandrina-pereira-join-group-income/) added her finishing touches to our schedule cards. Each guest was to receive a card, and it would let them know how the rest of the week was to unfold.
 
-![IMG_3805_small](https://groupincome.org/wp-content/uploads/2019/04/IMG_3805_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/IMG_3805_small.jpg')} alt='IMG_3805_small' />
 
 The only change we would make to this schedule would be to make Wednesday an additional day of island R&R.
 
@@ -49,15 +50,15 @@ Each day would start with morning exercise (for those inclined), followed by bre
 
 When they returned, [Andrea Devers](https://twitter.com/dotmacro) prepared amazing vegan breakfast for all — breakfast so legendary that it caused Sandrina to remark, "I could go vegan, if I had this."
 
-![IMG_3795_small](https://groupincome.org/wp-content/uploads/2019/04/IMG_3795_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/IMG_3795_small.jpg')} alt='IMG_3795_small' />
 
 Then came four hours of hacking.
 
-![DSC03623_small](https://groupincome.org/wp-content/uploads/2019/04/DSC03623_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/DSC03623_small.jpg')} alt='DSC03623_small' />
 
 Sometimes people worked inside, sometimes they worked outside.
 
-![DSC03846_small](https://groupincome.org/wp-content/uploads/2019/04/DSC03846_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/DSC03846_small.jpg')} alt='DSC03846_small' />
 
 On the first day I helped delegate tasks for the week, so that everyone could hit the ground running.
 
@@ -65,7 +66,7 @@ I would be finishing a rewrite of our core data structure, simplifying our codeb
 
 While we toiled away, Scott moved freely about the compound, looking and feeling very much at home. Perhaps this was because growing up, he had in fact called this island (Oahu) home.
 
-![IMG_3813_small](https://groupincome.org/wp-content/uploads/2019/04/IMG_3813_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/IMG_3813_small.jpg')} alt='IMG_3813_small' />
 
 Scott was there as our spirit guide. When he wasn't thinking or reading, he could be found writing yet another brilliant post for [his Basic Income blog](http://www.scottsantens.com). He has the uncanny ability to connect virtually any subject to Basic Income, and on the second night he took the group through [The BIG Experience](https://www.bigexperience.org) to inspire and remind us why we are working on this project in the first place.
 
@@ -77,7 +78,7 @@ I asked Scott the same question [we asked attendees of our previous hackathon](/
 
 Scott had brought with him several copies of the book *[Raising the Floor](https://www.powells.com/book/-9781610396257&PID=44806)* — an appropriate title given how succinctly it describes Group Income's algorithm (and Basic Income in general):
 
-![](https://groupincome.org/wp-content/uploads/2018/08/IMG_2434.jpg)
+<img alt='IMG_2434' src={resolvePath('/wp-content/uploads/2018/08/IMG_2434.jpg')} />
 
 Four hours flew by. Suddenly, it was time for lunch.
 
@@ -85,17 +86,14 @@ Four hours flew by. Suddenly, it was time for lunch.
 
 We were fortunate to have our very own gourmet vegan chef in the form of Andrea Devers (okTurtles director and hackathon organizer).
 
-![DSC03633_small](https://groupincome.org/wp-content/uploads/2019/04/DSC03633_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/DSC03633_small.jpg')} alt='DSC03633_small' />
 
 Whether it was rice pilaf or pizzadillas or chunky pasta — she had the team covered every day with healthy, delicious meals.
 
-![DSC03641_small](https://groupincome.org/wp-content/uploads/2019/04/DSC03636_small.jpg)
-
-![DSC05883_small](https://groupincome.org/wp-content/uploads/2019/04/DSC05883_small.jpg)
-
-![DSC03618_small](https://groupincome.org/wp-content/uploads/2019/04/DSC03618_small.jpg)
-
-![DSC03630_small](https://groupincome.org/wp-content/uploads/2019/04/DSC03630_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/DSC03636_small.jpg')} alt='DSC03641_small' />
+<img src={resolvePath('/wp-content/uploads/2019/04/DSC05883_small.jpg')} alt='DSC05883_small' />
+<img src={resolvePath('/wp-content/uploads/2019/04/DSC03618_small.jpg')} alt='DSC03618_small' />
+<img src={resolvePath('/wp-content/uploads/2019/04/DSC03630_small.jpg')} alt='DSC03630_small' />
 
 After lunch it was back to work!
 
@@ -103,19 +101,19 @@ After lunch it was back to work!
 
 Every hack night ended with a Show & Tell session.
 
-![DSC03657_small](https://groupincome.org/wp-content/uploads/2019/04/DSC03652_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/DSC03652_small.jpg')} alt='DSC03652_small' />
 
 We took turns sharing what we'd accomplished that day.
 
-![DSC03657_small](https://groupincome.org/wp-content/uploads/2019/04/DSC03657_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/DSC03657_small.jpg')} alt='DSC03657_small' />
 
 Concepts that started out as rough sketches on a whiteboard during the day...
 
-![](https://groupincome.org/wp-content/uploads/2018/08/IMG_2435.jpg)
+<img src={resolvePath('/wp-content/uploads/2018/08/IMG_2435.jpg')} alt='IMG_2435' />
 
 Would by nightfall transform into something beautiful.
 
-![image-20190422170818933](https://groupincome.org/wp-content/uploads/2019/05/contributions.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/05/contributions.jpg')} alt='image-20190422170818933' />
 
 In Group Income, users must be able to declare and see what they're giving and receiving from the group. This is where the idea for the design above comes from.
 
@@ -133,15 +131,15 @@ For this we would need to ask the user a question: whether or not they made more
 
 If they said "no", we ask them how much they make:
 
-![income-details-2](https://groupincome.org/wp-content/uploads/2019/05/income-details-2.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/05/income-details-2.jpg')} alt='income-details-2' />
 
 And if they say "yes", we ask them how much they'd like to pledge to the group:
 
-![income-details-3](https://groupincome.org/wp-content/uploads/2019/05/income-details-3.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/05/income-details-3.jpg')} alt='income-details-3' />
 
 With this and other new components implemented, we needed a design for a basic navigation bar, so we took a queue from apps like Slack, Gitter and Discord to create a familiar user experience:
 
-![dashboard](https://groupincome.org/wp-content/uploads/2019/05/dashboard.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/05/dashboard.jpg')} alt='dashboard' />
 
 You'll note that many parts of the UI have little blue links next to them that read, *"Propose change"*. These allow users to propose changes to group. For example, if a user wants to change the group's minimum income, they can click the *Propose change* link next to where the minimum income is displayed, and a dialog not entirely unlike the unfinished one below will appear:
 
@@ -155,18 +153,17 @@ It turns out there's no sense in hosting a hackathon in Hawaii if you plan to st
 
 Did you know that Hawaii has chickens everywhere?
 
-![IMG_3797_small](https://groupincome.org/wp-content/uploads/2019/04/IMG_3797_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/IMG_3797_small.jpg')} alt='IMG_3797_small' />
 
 They roam about the islands freely.
 
 On the way to the beach, we stopped by a fruit stand, and there we saw more chickens! You could sit right next to them. :)
 
-![IMG_2694_small](https://groupincome.org/wp-content/uploads/2019/04/IMG_2694_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/IMG_2694_small.jpg')} alt='IMG_2694_small' />
 
 We had a great time at the beach. The opening photograph to this post was taken there. It looked like you'd imagine a Hawaiian beach would.
 
-
-![IMG_3822_small](https://groupincome.org/wp-content/uploads/2019/04/IMG_3822_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/IMG_3822_small.jpg')} alt='IMG_3822_small' />
 
 The next day, it was back to work! Hack hack hackity hack hackathonnnnn!!!
 
@@ -176,13 +173,13 @@ During the hackathon we managed to merge 23 pull requests! That's like more than
 
 [^2]: That's a lot of pull requests.
 
-![merged pull requests](https://groupincome.org/wp-content/uploads/2019/04/merged-pull-requests.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/merged-pull-requests.jpg')} alt='merged pull requests' />
 
 So by the end everyone was (a) exhausted, (b) filled with a massive sense of accomplishment, and (c) ready to have fun on the island one last time!
 
 Which brings me to Tamas.
 
-![IMG_3955_small](https://groupincome.org/wp-content/uploads/2019/04/IMG_3955_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/IMG_3955_small.jpg')} alt='IMG_3955_small' />
 
 Just look at him. He looks like a badass, doesn't he? He *is* a badass. He can fly a freakin' helicopter! (For real.)
 
@@ -190,27 +187,27 @@ Just look at him. He looks like a badass, doesn't he? He *is* a badass. He can f
 
 Tamas, Sandrina, and Andrea took to the sky, and after seeing the photographs they brought back I kinda wish I had gone with them:
 
-![IMG_4068_small](https://groupincome.org/wp-content/uploads/2019/04/IMG_4068_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/IMG_4068_small.jpg')} alt='IMG_4068_small' />
 
-![IMG_4075_small](https://groupincome.org/wp-content/uploads/2019/04/IMG_4075_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/IMG_4075_small.jpg')} alt='IMG_4075_small' />
 
 These were taken from the helicopter Tamas was flying around Oahu.
 
 Did you know rainbows are actually circles? I did not fully appreciate this fact until they showed me this amazing photograph:
 
-![DSC05934_small](https://groupincome.org/wp-content/uploads/2019/04/DSC05934_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/DSC05934_small.jpg')} alt='DSC05934_small' />
 
 The rainbow is too big for the camera to capture all of it, but you can see the quarter of it that is the "side rainbow".
 
 I think modern video games are almost (but not quite) up to this level of realism:
 
-![IMG_3621_small](https://groupincome.org/wp-content/uploads/2019/04/IMG_3621_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/IMG_3621_small.jpg')} alt='IMG_3621_small' />
 
 ## Bye for now, Hawaii...
 
 We will miss you! Thanks to all attendees for the wonderful week, to the people of Hawaii for keeping Hawaii beautiful, to you, dear reader, for making it this far, and to all our supporters whose [donations](https://okturtles.org/donate/) make events like this possible.
 
-![IMG_3761_small](https://groupincome.org/wp-content/uploads/2019/04/IMG_3761_small.jpg)
+<img src={resolvePath('/wp-content/uploads/2019/04/IMG_3761_small.jpg')} alt='IMG_3761_small' />
 
 Our goal is to have the prototype in a usable state sometime this year, and we will likely put together another hackathon to help speed things along. See below for how you can participate in Group Income development too!
 

--- a/src/posts/margarida-botelho-and-pierre-schweiger-join-group-income.mdx
+++ b/src/posts/margarida-botelho-and-pierre-schweiger-join-group-income.mdx
@@ -13,28 +13,29 @@ permalink: /2020/01/margarida-botelho-and-pierre-schweiger-join-group-income/
 categories:
     - Uncategorized
 ---
+import { resolvePath } from '@/utils/helpers.js'
 
 Margarida and Pierre are great.
 
 "How great?" I hear you ask. Well, they're *sooo* great, that I absolutely must write a blog post about them.
 
-<img src="https://groupincome.org/wp-content/uploads/2020/01/margarida-botelho-300x300.jpg" alt="" width="300" height="300" class="alignright size-medium wp-image-1367" />
+<img src={resolvePath('/wp-content/uploads/2020/01/margarida-botelho-300x300.jpg')} alt="" width="300" height="300" class="alignright size-medium wp-image-1367" />
 
 Hailing from the great nation of Portugal, [Margarida Botelho](https://madeoflisboa.com/p/person/margarida-botelho) is a genius designer who's taking Group Income's user interface to the next level. Her design sense, attention to detail, dedication, and passion for users speaks for itself.
 
 Since joining the team, Margarida has worked diligently to produce a modern, responsive UI that works across devices:
 
-<img src="https://groupincome.org/wp-content/uploads/2020/01/gi-design-1-1024x682.jpg" alt="" width="1024" height="682" class="alignnone size-large wp-image-1368" />
+<img src={resolvePath('/wp-content/uploads/2020/01/gi-design-1-1024x682.jpg')} alt="" width="1024" height="682" class="alignnone size-large wp-image-1368" />
 
-<img src="https://groupincome.org/wp-content/uploads/2020/01/gi-design-2-1024x682.jpg" alt="" width="1024" height="682" class="alignnone size-large wp-image-1369" />
+<img src={resolvePath('/wp-content/uploads/2020/01/gi-design-2-1024x682.jpg')} alt="" width="1024" height="682" class="alignnone size-large wp-image-1369" />
 
-<img src="https://groupincome.org/wp-content/uploads/2020/01/gi-design-3-1024x682.jpg" alt="" width="1024" height="682" class="alignnone size-large wp-image-1370" />
+<img src={resolvePath('/wp-content/uploads/2020/01/gi-design-3-1024x682.jpg')} alt="" width="1024" height="682" class="alignnone size-large wp-image-1370" />
 
 Margarida shares her thoughts:
 
 > Joining this project is great, because I'm finally able to use my skills to work on something I truly believe in. When I joined Group Income, the idea of what this app would be was already very mature. Therefore, my work is to ensure that we break down these complex concepts and make them very easy to understand for our users.
 
-<img src="https://groupincome.org/wp-content/uploads/2020/01/pierre-300x300.jpg" alt="" width="300" height="300" class="alignright size-medium wp-image-1371" />
+<img src={resolvePath('/wp-content/uploads/2020/01/pierre-300x300.jpg')} alt="" width="300" height="300" class="alignright size-medium wp-image-1371" />
 
 After [Anikó](/articles/aniko-fejes-and-sandrina-pereira-join-group-income/) departed to devote her full attention to [CSSConf Budapest](https://twitter.com/cssconfbudapest), we needed additional help for the frontend. About 37 people applied for the job, and out of those we gave a special assignment to the top 5 (for which they were compensated). Using a point system, Margarida, Sandrina and I did our best to review submissions as objectively as we could, and this is how we discovered Pierre Schweiger. His functional and pixel-perfect implementation of Margarida's designs impressed us all, and we were thrilled to welcome him aboard!
 

--- a/src/posts/misconceptions-about-majority-rule.mdx
+++ b/src/posts/misconceptions-about-majority-rule.mdx
@@ -15,38 +15,41 @@ categories:
 tags:
     - voting
 ---
+import { resolvePath } from '@/utils/helpers.js'
 
-<!--
+{/*
 FYI, this is another example of academia gone wrong:
 http://www-groups.dcs.st-and.ac.uk/history/PrintHT/Voting.html
 
 - [ ] Post followup two days later.
 - [ ] post job listing to: https://govuejs.com/jobs/1/full-stack-engineer
--->
+*/}
 
 In our [previous post](/articles/what-makes-a-good-voting-system/), we explored the meaning of voting and what it takes to make a good voting system. In this _Part 2_, we hope to convince you that what you've been told about [majority rule](https://en.wikipedia.org/wiki/Majority_rule) is not only untrue, but harmful.
 
 <style>
-.sidenote {
-  display: block;
-  overflow-x: auto;
-  padding: 1em 1em;
-  border-radius: 6px;
-  background-color: #ebebeb;
-  color: #6C7E8F;
-  margin: 2em 1.5em 2em 1.5em;
-  font-size: 90%;
-}
-.sidenote b {
-  color: #6C7E8F !important;
-}
+  {`
+  .sidenote {
+    display: block;
+    overflow-x: auto;
+    padding: 1em 1em;
+    border-radius: 6px;
+    background-color: #ebebeb;
+    color: #6C7E8F;
+    margin: 2em 1.5em 2em 1.5em;
+    font-size: 90%;
+  }
+  .sidenote b {
+    color: #6C7E8F !important;
+  }
 
-hr {
-  margin: 0;
-}
-hr + p {
-  text-align: center;
-}
+  hr {
+    margin: 0;
+  }
+  hr + p {
+    text-align: center;
+  }
+  `}
 </style>
 
 - **[Voting Is Fairly New](#voting-is-fairly-new)**
@@ -95,7 +98,7 @@ Most descriptions of the theorem look something like this:
 
 However, the [original](http://www.eecs.harvard.edu/cs286r/courses/fall11/papers/May52.pdf) [theorem](https://sci-hub.tw/10.2307/1907651), as written by Kenneth May in 1952, looks like this:
 
-<img src="https://groupincome.org/wp-content/uploads/2016/07/mays-theorem-1024x134.jpg" alt="THEOREM: A group decision function is the method of simple majority decision if and only if it is always decisive, egalitarian, neutral, and positively responsive." width="1024" height="134" class="size-large wp-image-217" />
+<img src={resolvePath('/wp-content/uploads/2016/07/mays-theorem-1024x134.jpg')} alt="THEOREM: A group decision function is the method of simple majority decision if and only if it is always decisive, egalitarian, neutral, and positively responsive." width="1024" height="134" class="size-large wp-image-217" />
 
 Are either of these expressions of the theorem true?
 
@@ -131,7 +134,7 @@ Let's define these terms:
 - **Unweighted:** 1-person-1-vote style voting (as opposed to 1-dollar-1-vote style voting).
 - **Majority rule:** Unweighted voting rule with a threshold of 50%.
 - **Supermajority rule:** Unweighted voting rule with a threshold >50%. Typically, [2/3 or more](https://en.wikipedia.org/w/index.php?title=Supermajority&oldid=723462259#Common_supermajorities).
-- **Submajority rule:** Unweighted voting rule with a threshold of <50%.[^2]
+- **Submajority rule:** Unweighted voting rule with a threshold of {'<'}50%.[^2]
 
 [^1]: May did not explicitly state that $y$ refers to the status quo, but it is indicated by his four conditions and the implications (and problems) surrounding his theorem. If $y$ were something other than the ["status quo"](#confusion-over-status-quo), his theorem would fall apart because majority rule's ["neutrality"](#condition-iii-neutrality) would no longer be at all believable (it would be exactly _not neutral_, resulting in a move away from the status quo almost every time).
 
@@ -160,17 +163,29 @@ May's confusion around $D=0$ results in an even more serious problem, for it can
 
 <table>
 <tr><th>Votes</th><th>Possible meaning</th></tr>
-<tr><td><span class="math math-inline"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mo>&lt;</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo>&gt;</mo></mrow><annotation encoding="application/x-tex">&lt;0,0,0,0&gt;</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.5782em;vertical-align:-0.0391em;"></span><span class="mrel">&lt;</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:0.8389em;vertical-align:-0.1944em;"></span><span class="mord">0</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">0</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">0</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">0</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">&gt;</span></span></span></span></span></td>
-
-<td> "Nobody cares" aka "Indifference"</td></tr>
-<tr><td><span class="math math-inline"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mo>&lt;</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo>&gt;</mo></mrow><annotation encoding="application/x-tex">&lt;0,0,0,0&gt;</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.5782em;vertical-align:-0.0391em;"></span><span class="mrel">&lt;</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:0.8389em;vertical-align:-0.1944em;"></span><span class="mord">1</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">1</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">-1</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">-1</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">&gt;</span></span></span></span></span> </td>
-<td> "Everybody cares"                </td></tr>
-<tr><td><span class="math math-inline"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mo>&lt;</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo>&gt;</mo></mrow><annotation encoding="application/x-tex">&lt;0,0,0,0&gt;</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.5782em;vertical-align:-0.0391em;"></span><span class="mrel">&lt;</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:0.8389em;vertical-align:-0.1944em;"></span><span class="mord">0</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">-1</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">-1</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">0</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">&gt;</span></span></span></span></span></td><td> "Some care"                      </td></tr>
+<tr>
+  <td>
+    <span class="math math-inline"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mo>&lt;</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo>&gt;</mo></mrow><annotation encoding="application/x-tex">&lt;0,0,0,0&gt;</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.5782em;vertical-align:-0.0391em;"></span><span class="mrel">&lt;</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:0.8389em;vertical-align:-0.1944em;"></span><span class="mord">0</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">0</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">0</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">0</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">&gt;</span></span></span></span></span>
+  </td>
+  <td>"Nobody cares" aka "Indifference"</td>
+</tr>
+<tr>
+  <td>
+    <span class="math math-inline"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mo>&lt;</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo>&gt;</mo></mrow><annotation encoding="application/x-tex">&lt;0,0,0,0&gt;</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.5782em;vertical-align:-0.0391em;"></span><span class="mrel">&lt;</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:0.8389em;vertical-align:-0.1944em;"></span><span class="mord">1</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">1</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">-1</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">-1</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">&gt;</span></span></span></span></span>
+  </td>
+  <td>"Everybody cares"</td>
+</tr>
+<tr>
+  <td>
+    <span class="math math-inline"><span class="katex"><span class="katex-mathml"><math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><mo>&lt;</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo separator="true">,</mo><mn>0</mn><mo>&gt;</mo></mrow><annotation encoding="application/x-tex">&lt;0,0,0,0&gt;</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="base"><span class="strut" style="height:0.5782em;vertical-align:-0.0391em;"></span><span class="mrel">&lt;</span><span class="mspace" style="margin-right:0.2778em;"></span></span><span class="base"><span class="strut" style="height:0.8389em;vertical-align:-0.1944em;"></span><span class="mord">0</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">-1</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">-1</span><span class="mpunct">,</span><span class="mspace" style="margin-right:0.1667em;"></span><span class="mord">0</span><span class="mspace" style="margin-right:0.2778em;"></span><span class="mrel">&gt;</span></span></span></span></span>
+  </td>
+  <td>"Some care"</td>
+</tr>
 </table>
 
 Our [previous post](/articles/what-makes-a-good-voting-system/) explains why $D=0$ does not (typically) mean "indifference" but is indicative of disagreement:
 
-<img src="https://groupincome.org/wp-content/uploads/2016/06/voting-v6.2.png" alt="What &quot;Voting&quot; Means" style="box-shadow:1px 1px 3px rgba(1, 1, 1, 0.25); width: 80%;" class="aligncenter size-full wp-image-119" />
+<img src={resolvePath('/wp-content/uploads/2016/06/voting-v6.2.png')} alt="What &quot;Voting&quot; Means" style="box-shadow:1px 1px 3px rgba(1, 1, 1, 0.25); width: 80%;" class="aligncenter size-full wp-image-119" />
 
 However, even if we used the turnout to measure "indifference", that is also not necessarily a reliable way of representing indifference. For example, a low turnout in a presidential election *might* mean that people do not care, or it could mean that they care but do not approve of either option.
 
@@ -183,7 +198,7 @@ Onward!
 
 Here's a screenshot of Condition I from May's paper:
 
-<img src="https://groupincome.org/wp-content/uploads/2016/07/condition1-always-decisive-e1472518395474-1024x248.jpg" alt="CONDITION I: The group decision function is defined and single valued for every element of U X U X ... X U. We might describe this condition by saying that the method must be decisive and universally applicable, or more briefly always decisive, since it must specify a unique decision (even if this decision is to be indifferent) for any individual preferences." width="1024" height="248" class="aligncenter size-large wp-image-236" />
+<img src={resolvePath('/wp-content/uploads/2016/07/condition1-always-decisive-e1472518395474-1024x248.jpg')} alt="CONDITION I: The group decision function is defined and single valued for every element of U X U X ... X U. We might describe this condition by saying that the method must be decisive and universally applicable, or more briefly always decisive, since it must specify a unique decision (even if this decision is to be indifferent) for any individual preferences." width="1024" height="248" class="aligncenter size-large wp-image-236" />
 
 That may sound fancy, but all it says is: "A _group decision function_ is a [function](https://en.wikipedia.org/w/index.php?title=Function_(mathematics)&oldid=735355683) _[that outputs -1, 0, or 1]_."[^3]
 
@@ -215,7 +230,7 @@ The term "egalitarian" only appears once in the entire paper: in the [theorem st
 
 [^4]: Note that **this is sloppy, bad math.** Mathematical theorems must define terms precisely and then use them in a consistent manner. Instead, May plays word games with the reader, misleading them into believing Condition II implies majority rule is ["egalitarian"](http://www.thefreedictionary.com/egalitarian) or ["anonymous"](http://www.thefreedictionary.com/anonymous) when the math implies neither.
 
-<img src="https://groupincome.org/wp-content/uploads/2016/07/condition2-anonymity-e1472519254126-1024x399.jpg" alt="The second condition is that each individual be treated the same as far as his influence on the outcome is concerned. This means that in f(D1, D2, ---, Dn) we could interchange any two of the variables without changing the result. CONDITION II: The group decision function is a symmetricfunction of its arguments. This condition might well be termed anonymity, since it means that D is determined only by the values of the Di that appear, regardless of how they are assigned to individuals as indicated by subscripts (names). A more usual label is equality." width="1024" height="399" class="aligncenter size-large wp-image-222" />
+<img src={resolvePath('/wp-content/uploads/2016/07/condition2-anonymity-e1472519254126-1024x399.jpg')} alt="The second condition is that each individual be treated the same as far as his influence on the outcome is concerned. This means that in f(D1, D2, ---, Dn) we could interchange any two of the variables without changing the result. CONDITION II: The group decision function is a symmetricfunction of its arguments. This condition might well be termed anonymity, since it means that D is determined only by the values of the Di that appear, regardless of how they are assigned to individuals as indicated by subscripts (names). A more usual label is equality." width="1024" height="399" class="aligncenter size-large wp-image-222" />
 
 This simply says votes are _unweighted_ and their order doesn't matter. That is, we're focusing on decision rules of the [1-person-1-vote](https://en.wikipedia.org/wiki/One_man,_one_vote) variety (and not, e.g., the [1-share-1-vote variety](https://en.wikipedia.org/wiki/One_share,_one_vote)).
 
@@ -234,7 +249,7 @@ Therefore, the math of Condition II is not represented by the English.[^5]
 
 Condition III is the most [frequently](https://newrepublic.com/article/116172/against-filibusters-super-majorities-melissa-schwartzberg-reviewed) [cited](http://www.libertylawsite.org/2014/01/22/more-on-supermajority-rules-mays-theorem/) justification of the four conditions:
 
-<img src="https://groupincome.org/wp-content/uploads/2016/07/condition3-neutrality-1024x257.jpg" alt="Another way of justifying this is by considering that we might have decided in the first place to assign the values -1 and 1 in the opposite way, and we do not want this to make any difference. Accordingly: CONDITION III: f(-D1, -D2, *. *,Dn) = - f(D1 , D2, ...* Dn) For obvious reasons the mathematical term &quot;odd&quot; does not seem con- venient in this context, and we describe this property as neutrality." width="1024" height="257" class="aligncenter size-large wp-image-233" />
+<img src={resolvePath('/wp-content/uploads/2016/07/condition3-neutrality-1024x257.jpg')} alt="Another way of justifying this is by considering that we might have decided in the first place to assign the values -1 and 1 in the opposite way, and we do not want this to make any difference. Accordingly: CONDITION III: f(-D1, -D2, *. *,Dn) = - f(D1 , D2, ...* Dn) For obvious reasons the mathematical term &quot;odd&quot; does not seem con- venient in this context, and we describe this property as neutrality." width="1024" height="257" class="aligncenter size-large wp-image-233" />
 
 It is Condition III that's referenced when someone says majority rule is "neutral with respect to the status quo". For example, Adrian Vermeule's [review](https://newrepublic.com/article/116172/against-filibusters-super-majorities-melissa-schwartzberg-reviewed) of a book on Social Choice Theory says:
 
@@ -264,7 +279,7 @@ If we care at all about the status quo, we have no choice but to pay attention t
 
 It's nice that May somewhat acknowledges this, although few seem to have noticed his footnote:
 
-<img src="https://groupincome.org/wp-content/uploads/2016/07/footnote7-1024x137.jpg" alt="7 There are many situations where this neutrality is not desirable. It goes without saying that our purpose here is to illuminate the formal characteristics of simple majority decision and not to assert any special value or universality for the stated conditions." width="1024" height="137" class="aligncenter size-large wp-image-253" />
+<img src={resolvePath('/wp-content/uploads/2016/07/footnote7-1024x137.jpg')} alt="7 There are many situations where this neutrality is not desirable. It goes without saying that our purpose here is to illuminate the formal characteristics of simple majority decision and not to assert any special value or universality for the stated conditions." width="1024" height="137" class="aligncenter size-large wp-image-253" />
 
 [^6]: We maintain [a giant list](/2016/06/what-makes-a-good-voting-system/#considerations) of important considerations.
 
@@ -273,7 +288,7 @@ It's nice that May somewhat acknowledges this, although few seem to have noticed
 
 The final condition is a nice segue to understanding the real difference between _majority rule_ and other voting rules, although it is by understanding _the misunderstanding_ of the condition that we get there:
 
-<img src="https://groupincome.org/wp-content/uploads/2016/07/condition4-positive-responsiveness-e1472612112472-1024x325.jpg" alt="The final condition that we place on the decision function is that it respond to changes in individual preferences in a &quot;positive&quot; way. By this we mean that if the group decision is indifference or favorable to x, and if the individual preferences remain the same except that a single individual changes in a way favorable to x, then the group decision becomes favorable to x. More precisely: CONDITION IV : If D=f(D1,D2, ... ,Dn) = 0 or 1, and D&#039;i=Di for all i != i0, and Di0 &gt; Dio, then D&#039; = f(D&#039;1, ... ,D&#039;n) = 1." width="1024" height="325" class="aligncenter size-large wp-image-235" />
+<img src={resolvePath('/wp-content/uploads/2016/07/condition4-positive-responsiveness-e1472612112472-1024x325.jpg')} alt="The final condition that we place on the decision function is that it respond to changes in individual preferences in a &quot;positive&quot; way. By this we mean that if the group decision is indifference or favorable to x, and if the individual preferences remain the same except that a single individual changes in a way favorable to x, then the group decision becomes favorable to x. More precisely: CONDITION IV : If D=f(D1,D2, ... ,Dn) = 0 or 1, and D&#039;i=Di for all i != i0, and Di0 &gt; Dio, then D&#039; = f(D&#039;1, ... ,D&#039;n) = 1." width="1024" height="325" class="aligncenter size-large wp-image-235" />
 
 In other words, if a group is initially "indifferent" towards a proposition and someone changes their vote to be more favorable, the proposition succeeds.
 
@@ -370,7 +385,7 @@ Day after tomorrow we'll cover the final topics:
 - **Avoiding May's Mistake**
 - **Repeating May's Mistake For Great Profit**
 
-_Thanks to [Simon Grondin](http://simongrondin.name/), [Andrea Devers](https://twitter.com/dotmacro), and [Jason Krueger](https://twitter.com/grandcamel) for reviewing this post, and to the members of `r/math` and `r/askmath` for their insightful feedback, with special thanks to RosaDecidua and wonkey_monkey. You can follow [the author](https://twitter.com/taoeffect) and [Group Income](https://twitter.com/Group_Income) on twitter.<!--Want to work on basic income with us? <a href="/positions" class="orange">We're hiring!</a>-->_
+_Thanks to [Simon Grondin](http://simongrondin.name/), [Andrea Devers](https://twitter.com/dotmacro), and [Jason Krueger](https://twitter.com/grandcamel) for reviewing this post, and to the members of `r/math` and `r/askmath` for their insightful feedback, with special thanks to RosaDecidua and wonkey_monkey. You can follow [the author](https://twitter.com/taoeffect) and [Group Income](https://twitter.com/Group_Income) on twitter.
 
 ## A note
 

--- a/src/posts/victor-morrow-joins-group-income.mdx
+++ b/src/posts/victor-morrow-joins-group-income.mdx
@@ -13,12 +13,13 @@ permalink: /2016/11/victor-morrow-joins-group-income/
 categories:
     - Uncategorized
 ---
+import { resolvePath } from '@/utils/helpers.js'
 
 # Victor Morrow Joins Group Income!
 
 After a long search, we found our dev: please welcome Victor Morrow as our new lead frontend developer.
 
-<img src="https://groupincome.org/wp-content/uploads/2016/11/victor.jpg" alt="" width="256" height="256" class="alignright size-full wp-image-644" />
+<img src={resolvePath('/wp-content/uploads/2016/11/victor.jpg')} alt="" width="256" height="256" class="alignright size-full wp-image-644" />
 
 Victor is an amazing human being and developer. A resident of D.C., he's made great contributions to the same area our team has been working in for quite some time.
 

--- a/src/posts/what-makes-a-good-voting-system.mdx
+++ b/src/posts/what-makes-a-good-voting-system.mdx
@@ -15,6 +15,7 @@ categories:
 tags:
     - voting
 ---
+import { resolvePath } from '@/utils/helpers.js'
 
 It's not completely clear how this happened, but somewhere in our history it was decided that, _"A majority voting in favor of something indicates the presence of agreement, and we should proceed ahead."_
 
@@ -38,7 +39,7 @@ However, that is only partially true if the group decided—formally and beforeh
 
 Even then, the "We" of "We're in agreement" only refers to half the group. From the outside, it appears as if _two_ groups are in discord with one another:
 
-<img src="https://groupincome.org/wp-content/uploads/2016/06/voting-v6.2.png" alt="What &quot;Voting&quot; Means" style="box-shadow:1px 1px 3px rgba(1, 1, 1, 0.25); width: 80%;" class="aligncenter size-full wp-image-119" />
+<img src={resolvePath('/wp-content/uploads/2016/06/voting-v6.2.png')} alt="What &quot;Voting&quot; Means" style="box-shadow:1px 1px 3px rgba(1, 1, 1, 0.25); width: 80%;" class="aligncenter size-full wp-image-119" />
 
 Perhaps this method of making collective decisions is not always the best way to go?
 
@@ -111,7 +112,7 @@ In Group Income, voting plays at least four important roles:
 
 Here is one of our mockups for the UI that we'll be experimenting with when users create a group. You can think of it as setting up the _Group Constitution:_
 
-<img src="https://groupincome.org/wp-content/uploads/2016/06/group-setup-sm-v1.png" alt="Group Creation Screen" class="aligncenter size-full wp-image-114" />
+<img src={resolvePath('/wp-content/uploads/2016/06/group-setup-sm-v1.png')} alt="Group Creation Screen" class="aligncenter size-full wp-image-114" />
 
 A few notes:
 


### PR DESCRIPTION
closes #105 

To use `resolvePath()` utility function within various `.md` files, they had to be first turned into `.mdx` (MD + JSX) files, which is what large portion of this PR has.

and some of the `.md` specific syntax had to be turned into the `jsx` equivalent along with that.

e.g.)
```
![alt name](url)
```
->
```
<img src={resolvePath('url')} alt='alt name' />
```
Thanks,