### PR TITLE
#128 - FAQ nav-bar stuck to the wrong position

### DIFF
--- a/src/components/FAQ.vue
+++ b/src/components/FAQ.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="container c-container" id="faqContainer">
-    <ul class="c-nav" id="faqNav">
+    <ul class="c-nav">
       <li class="scrollingLink">
         <button class="is-unstyled" @click="scrollTo('#general')">General</button>
       </li>
@@ -230,18 +230,6 @@ export default {
     },
 
     scrollAnimation () {
-      this.gsap.to('#faqNav', {
-        scrollTrigger: {
-          trigger: '#faqNav',
-          pin: true,
-          start: `2 ${document.getElementsByClassName("c-header")[0].offsetHeight}`,
-          pinSpacing: false,
-          pinReparent: true,
-          end: 'bottom 308',
-          endTrigger: '#faqContainer'
-        }
-      })
-
       const navLinks = this.gsap.utils.toArray('.scrollingLink')
       const panels = this.gsap.utils.toArray('.panel')
 
@@ -285,6 +273,8 @@ export default {
 @import "../styles/_mixins";
 
 .c-nav {
+  position: sticky;
+  top: var(--gi-header-height);
   height: 3rem;
   display: flex;
   flex-wrap: wrap;
@@ -299,11 +289,15 @@ export default {
   @include phone {
     // justify-content: center;
     flex-wrap: nowrap;
-    overflow: scroll;
     height: auto;
+
     li {
       padding: .5rem;
     }
+  }
+
+  @include tablet {
+    padding: 0 0.5rem;
   }
 }
 

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -40,16 +40,14 @@ import Hamburger from './Hamburger.vue'
     display: flex;
     align-items: center;
     width: 100%;
-    height: $headerHeightMobile;
+    height: var(--gi-header-height);
     max-width: calc(100% - 2rem);
 
     @include tablet {
-      height: $headerHeightTablet;
       max-width: calc(100% - 8rem);
     }
 
     @include desktop {
-      height: $headerHeight;
       max-width: $maxDesktop;
     }
   }

--- a/src/components/HomeAnimation.vue
+++ b/src/components/HomeAnimation.vue
@@ -602,14 +602,9 @@ export default {
   align-items: center;
   justify-content: center;
 
-  min-height: calc(100vh - #{$headerHeightMobile});
-
-  @include tablet {
-    min-height: calc(100vh - #{$headerHeightTablet});
-  }
+  min-height: calc(100vh - var(--gi-header-height));
 
   @include desktop {
-    min-height: calc(100vh - #{$headerHeight});
     background-size: auto;
   }
 }

--- a/src/styles/_utilities.scss
+++ b/src/styles/_utilities.scss
@@ -1,3 +1,16 @@
+:root {
+  // toolbar-height is needed in various places in defining layouts.
+  --gi-header-height: #{$headerHeightMobile};
+
+  @include tablet {
+    --gi-header-height: #{$headerHeightTablet};
+  }
+
+  @include desktop {
+    --gi-header-height: #{$headerHeight};
+  }
+}
+
 .is-unstyled {
   background: none;
   border: none;


### PR DESCRIPTION
closes #128 

There was a scroll animation attached to the navigation menu which apparently does not work properly and mess up when viewport size changes. So removed it and specified `position: sticky` css style to make sure it correctly attaches to the bottom of the website toolbar while scrolling.

![image](https://github.com/user-attachments/assets/5986e4c7-de89-42ec-9fa4-0adc73b817f9)


<img src='' width='480'>