### PR TITLE
#139 - Cropped-off answer in FAQ

### DIFF
--- a/src/components/Accordion.vue
+++ b/src/components/Accordion.vue
@@ -164,7 +164,7 @@ dd {
   }
 
   &.active {
-    max-height: 40rem;
+    max-height: 100rem;
   }
 
   .description {

--- a/src/components/FAQ.vue
+++ b/src/components/FAQ.vue
@@ -339,7 +339,7 @@ dd {
   }
 
   &.active {
-    max-height: 40rem;
+    max-height: 100rem;
   }
 }
 


### PR DESCRIPTION
closes #139 

inefficient `max-height` value in the accordion caused this issue. so increased it.

<img src='https://github.com/user-attachments/assets/c09d64cd-6b95-4abd-b1b8-c12e9776e34e' width='430'>