### PR TITLE
Fix: Update GitHub Actions versions

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -59,7 +59,7 @@ jobs:
           cache-dependency-path: ${{ env.BUILD_PATH }}/package-lock.json
       - run: npm install && npm run build
         working-directory: ${{ env.BUILD_PATH }}
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: ${{ env.BUILD_PATH }}/dist
 
@@ -73,4 +73,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
(This was done by Jules)

I updated `actions/upload-pages-artifact` from `v1` to `v3` and `actions/deploy-pages` from `v1` to `v4` in the Astro deployment workflow.

This change addresses a deployment failure caused by an error "Missing download info for actions/upload-artifact@v3". Updating these actions to their latest versions should resolve the issue and ensure compatibility with the current GitHub Actions runner environment.