### PR TITLE
fix the overlapping UI bug

### DIFF
--- a/src/pages/[locale]/about-us.astro
+++ b/src/pages/[locale]/about-us.astro
@@ -238,6 +238,9 @@ export async function getStaticPaths() {
 }
 
 .c-container {
+  position: relative;
+  z-index: 2;
+
   &-image {
     max-width: 80%;
     margin: 0 auto 3rem auto;


### PR DESCRIPTION
closes #194 

That paragraph needed a proper z-index with relative position.
Checked the other pages that also have the circle design and haven't seen the same bug.

<img width="100%" alt="image" src="https://github.com/user-attachments/assets/959ba371-cd70-4190-b68a-a0f909646444" />
